### PR TITLE
Fix int overflow in KSW2_gg2_SSE memory allocation

### DIFF
--- a/ksw2_exts2_sse.c
+++ b/ksw2_exts2_sse.c
@@ -252,7 +252,7 @@ void ksw_exts2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 #endif
 			}
 		} else if (!(flag&KSW_EZ_RIGHT)) { // gap left-alignment
-			__m128i *pr = p + r * n_col_ - st_;
+			__m128i *pr = p + (size_t)r * n_col_ - st_;
 			off[r] = st, off_end[r] = en;
 			for (t = st_; t <= en_; ++t) {
 				__m128i d, z, a, b, a2, a2a, xt1, x2t1, vt1, ut, tmp, tmp2;
@@ -295,7 +295,7 @@ void ksw_exts2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 				_mm_store_si128(&pr[t], d);
 			}
 		} else { // gap right-alignment
-			__m128i *pr = p + r * n_col_ - st_;
+			__m128i *pr = p + (size_t)r * n_col_ - st_;
 			off[r] = st, off_end[r] = en;
 			for (t = st_; t <= en_; ++t) {
 				__m128i d, z, a, b, a2, a2a, xt1, x2t1, vt1, ut, tmp, tmp2;

--- a/ksw2_gg2.c
+++ b/ksw2_gg2.c
@@ -16,7 +16,7 @@ int ksw_gg2(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *t
 	if (w < 0) w = tlen > qlen? tlen : qlen;
 	n_col = w + 1 < tlen? w + 1 : tlen;
 	if (m_cigar_ && n_cigar_ && cigar_) {
-		p = (uint8_t*)kcalloc(km, (qlen + tlen) * n_col, 1);
+		p = (uint8_t*)kcalloc(km, (size_t)(qlen + tlen) * n_col, 1);
 		off = (int*)kmalloc(km, (qlen + tlen) * sizeof(int));
 	}
 
@@ -44,7 +44,7 @@ int ksw_gg2(void *km, int qlen, const uint8_t *query, int tlen, const uint8_t *t
 			s[t] = mat[target[t] * m + qr[t + qlen - 1 - r]];
 		// core loop
 		if (m_cigar_ && n_cigar_ && cigar_) {
-			uint8_t *pr = p + r * n_col;
+			uint8_t *pr = p + (size_t)r * n_col;
 			off[r] = st;
 			for (t = st; t <= en; ++t) {
 				/* At the beginning of the loop, v1=v(r-1,t-1), x1=x(r-1,t-1), u[t]=u(r-1,t), v[t]=v(r-1,t), x[t]=x(r-1,t), y[t]=y(r-1,t)

--- a/ksw2_gg2_sse.c
+++ b/ksw2_gg2_sse.c
@@ -33,7 +33,7 @@ int ksw_gg2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uint8_
 	u = (__m128i*)(((size_t)mem + 15) >> 4 << 4); // 16-byte aligned
 	v = u + tlen_, x = v + tlen_, y = x + tlen_, s = y + tlen_;
 	qr = (uint8_t*)kcalloc(km, qlen, 1);
-	mem2 = (uint8_t*)kmalloc(km, ((qlen + tlen - 1) * n_col_ + 1) * 16);
+	mem2 = (uint8_t*)kmalloc(km, ((size_t)(qlen + tlen - 1) * n_col_ + 1) * 16);
 	p = (__m128i*)(((size_t)mem2 + 15) >> 4 << 4);
 	off = (int*)kmalloc(km, (qlen + tlen - 1) * sizeof(int));
 
@@ -66,7 +66,7 @@ int ksw_gg2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uint8_
 		x1_ = _mm_cvtsi32_si128(x1);
 		v1_ = _mm_cvtsi32_si128(v1);
 		st_ = st>>4, en_ = en>>4;
-		pr = p + r * n_col_ - st_;
+		pr = p + (size_t)r * n_col_ - st_;
 		for (t = st_; t <= en_; ++t) {
 			__m128i d, z, a, b, xt1, vt1, ut, tmp;
 


### PR DESCRIPTION
This fixes an int overflow and consecutive crash for alignments that need more than `2.1GB` of memory.
The other alignment modes already correctly cast to `size_t` for this; it was simply missing in a few places.